### PR TITLE
Add music and genres table in the schema file

### DIFF
--- a/schema_music.sql
+++ b/schema_music.sql
@@ -1,0 +1,27 @@
+-- Create database
+CREATE DATABASE catalog_of_my_things;
+
+-- Genres table
+CREATE TABLE genres(
+  id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  name VARCHAR(255) NOT NULL
+);
+
+-- Items table
+CREATE TABLE items(
+  id            INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  genre_id      INT REFERENCES genres(id),
+  author_id     INT REFERENCES authors(id),
+  source_id     INT REFERENCES sources(id),
+  label_id      INT REFERENCES labels(id),
+  publish_date  DATE NOT NULL,
+  archived      BOOLEAN NOT NULL,
+  type          VARCHAR(255) NOT NULL
+);
+
+-- Music albums table
+CREATE TABLE music_albums(
+  id            INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  on_spotify    BOOLEAN NOT NULL,
+  FOREIGN KEY (id) REFERENCES items(id)
+);


### PR DESCRIPTION
Created a schema.sql file with tables that will be analogical to the structure of the classes that I created:

1.     music_albums table (add all properties and associations from the parent Item class as table columns)

2.     genres table

[Issue Link](https://github.com/shayan1234554321/Ruby-capston/issues/16
)